### PR TITLE
chore: add dependabot cooldown, align interval and assignee

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,8 @@ version: 2
 updates:
 - package-ecosystem: "github-actions"
   directory: "/"
+  cooldown:
+    default-days: 7
   schedule:
     interval: "weekly"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Align the Dependabot configuration with the other repositories:

- Add a 7-day `cooldown` (`default-days: 7`) to every update block
- Use `weekly` as update interval
- Set the assignee to `thenativeweb/internal_dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)